### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A golang server and CLI utility to generate autocomplete items from shorthand in
 
 ## Installation
 
-`go get github.com/zerowidth/gh-shorthand` to install to `$GOPATH/bin` (default: `~/go/bin`).
+`go install github.com/zerowidth/gh-shorthand@latest` to install to `$GOPATH/bin` (default: `~/go/bin`).
 
 You can run `gh-shorthand --help` to make sure it's working.
 


### PR DESCRIPTION
Following these I was told:

```
fermion@boeuf-185 ~> go get github.com/zerowidth/gh-shorthand
        go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
```